### PR TITLE
Add try_void to PaymentMethod

### DIFF
--- a/app/models/solidus_bolt/payment_method.rb
+++ b/app/models/solidus_bolt/payment_method.rb
@@ -26,6 +26,12 @@ module SolidusBolt
       bolt_config.environment_url
     end
 
+    def try_void(payment)
+      return false unless payment.source.can_void?(payment)
+
+      gateway.void(payment.response_code, originator: payment)
+    end
+
     private
 
     def bolt_config

--- a/spec/models/solidus_bolt/payment_method_spec.rb
+++ b/spec/models/solidus_bolt/payment_method_spec.rb
@@ -18,4 +18,29 @@ RSpec.describe SolidusBolt::PaymentMethod, type: :model do
       expect(described_class.new.partial_name).to eq 'bolt'
     end
   end
+
+  describe '#try_void' do
+    let(:payment) { create(:payment) }
+
+    context 'when the payment can be voided' do
+      subject(:try_void) { described_instance.try_void(payment) }
+
+      let(:described_instance) { described_class.new }
+      let(:response) { ActiveMerchant::Billing::Response.new(true, 'Transaction voided', {}, authorization: '123') }
+
+      before do
+        allow(payment.source).to receive(:can_void?).and_return(true)
+        allow(described_instance.gateway).to receive(:void).and_return(response)
+      end
+
+      it 'calls void on the gateway' do
+        try_void
+
+        expect(described_instance.gateway).to have_received(:void).with(
+          payment.response_code,
+          originator: payment
+        )
+      end
+    end
+  end
 end


### PR DESCRIPTION
`try_void` method is called to check if it's possible to void a payment,
it's required to void a payment when the cancel button on the order
admin page is clicked.

Tested on https://merchant-sandbox.bolt.com/transaction/2227-F64Z-22WR