### PR TITLE
Add shipments to authorize card api

### DIFF
--- a/app/decorators/models/solidus_bolt/order_decorator.rb
+++ b/app/decorators/models/solidus_bolt/order_decorator.rb
@@ -7,6 +7,7 @@ module SolidusBolt
         total_amount: display_total.cents,
         order_reference: number,
         currency: currency,
+        shipments: bolt_shipments_payload,
         items: line_items.map do |line_item|
           {
             sku: line_item.sku,
@@ -34,6 +35,10 @@ module SolidusBolt
     end
 
     private
+
+    def bolt_shipments_payload
+      shipments.map(&:bolt_shipment)
+    end
 
     def cents(float)
       (float * 100).to_i

--- a/app/decorators/models/solidus_bolt/shipment_decorator.rb
+++ b/app/decorators/models/solidus_bolt/shipment_decorator.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module SolidusBolt
+  module ShipmentDecorator
+    def bolt_shipment
+      {
+        shipping_address: order.ship_address.bolt_address(order.email),
+        reference: number,
+        cost: display_total.cents
+      }
+    end
+
+    Spree::Shipment.prepend(self)
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,7 +2,7 @@
 
 solidus_bolt_configuration = SolidusBolt::BoltConfiguration.fetch
 
-solidus_bolt_configuration.environment = ENV['BOLT_ENVIRONMENT']
+solidus_bolt_configuration.environment = ENV.fetch('BOLT_ENVIRONMENT', 'sandbox')
 solidus_bolt_configuration.merchant_public_id = ENV['BOLT_MERCHANT_PUBLIC_ID']
 solidus_bolt_configuration.division_public_id = ENV['BOLT_DIVISION_PUBLIC_ID']
 solidus_bolt_configuration.api_key = ENV['BOLT_API_KEY']

--- a/spec/decorators/models/solidus_bolt/order_decorator_spec.rb
+++ b/spec/decorators/models/solidus_bolt/order_decorator_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe SolidusBolt::OrderDecorator do
         total_amount: (order.total * 100).to_i,
         order_reference: order.number,
         currency: 'USD',
+        shipments: array_including(hash_including(:reference)),
         items: [{
           sku: order.line_items.first.sku,
           name: order.line_items.first.name,
@@ -16,7 +17,8 @@ RSpec.describe SolidusBolt::OrderDecorator do
           quantity: 1
         }]
       }
-      expect(order.bolt_cart).to eq(result)
+
+      expect(order.bolt_cart).to match hash_including(result)
     end
   end
 

--- a/spec/decorators/models/solidus_bolt/shipment_decorator_spec.rb
+++ b/spec/decorators/models/solidus_bolt/shipment_decorator_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+RSpec.describe SolidusBolt::ShipmentDecorator do
+  describe '#bolt_shipment' do
+    subject(:bolt_shipment) { shipment.bolt_shipment }
+
+    let(:shipment) { create(:shipment, number: 'S000000001') }
+    let(:ship_address) { shipment.order.ship_address }
+
+    it 'is expected' do
+      expect(bolt_shipment).to match hash_including(
+        shipping_address: hash_including(postal_code: ship_address.zipcode, country_code: ship_address.country_iso),
+        reference: 'S000000001',
+        cost: 10_000
+      )
+    end
+  end
+end


### PR DESCRIPTION
Add shipments data to [Authorize Card API](https://help.bolt.com/api-bolt/#tag/Transactions/operation/MerchantAuthorize) payload.
In this way, the shipment will be saved on the Bolt Transaction.

QA:
- place an order
- check that the shipment address stored on the transaction

ref https://merchant-sandbox.bolt.com/transaction/8RNG-7CJQ-HXD4