### PR TITLE
Update Rails version requirements on gemspec

### DIFF
--- a/solidus_bolt.gemspec
+++ b/solidus_bolt.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'deface'
   spec.add_dependency 'httparty'
   spec.add_dependency 'omniauth-bolt'
-  spec.add_dependency 'rails', ['>0.a', '< 7.a']
+  spec.add_dependency 'rails'
   spec.add_dependency 'solidus_auth_devise'
   spec.add_dependency 'solidus_core', ['>= 2.0.0', '< 4']
   spec.add_dependency 'solidus_social'


### PR DESCRIPTION
Updated the rails version requirements which were capped at `< 7.0` for the gem.

This requirement caused the gem to not work with the latest solidus version which is based off Rails 7