### PR TITLE
Upgrade rails version

### DIFF
--- a/app/services/solidus_bolt/base_service.rb
+++ b/app/services/solidus_bolt/base_service.rb
@@ -10,8 +10,8 @@ module SolidusBolt
       raise NotImplementedError
     end
 
-    def self.call(*args)
-      new(*args).call
+    def self.call(...)
+      new(...).call
     end
 
     private

--- a/bin/sandbox
+++ b/bin/sandbox
@@ -54,6 +54,8 @@ gem 'solidus_auth_devise', '>= 2.1.0'
 gem 'rails-i18n'
 gem 'solidus_i18n'
 
+gem 'net-smtp', require: false
+
 gem '$extension_name', path: '..'
 
 group :test, :development do

--- a/solidus_bolt.gemspec
+++ b/solidus_bolt.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.metadata['source_code_uri'] = 'https://github.com/nebulab/solidus_bolt'
   spec.metadata['changelog_uri'] = 'https://github.com/nebulab/solidus_bolt/blob/master/CHANGELOG.md'
 
-  spec.required_ruby_version = Gem::Requirement.new('~> 2.5')
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.5.0")
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'httparty'
   spec.add_dependency 'multi_json'
   spec.add_dependency 'omniauth-bolt'
-  spec.add_dependency 'rails'
+  spec.add_dependency 'rails', '~> 6.0'
   spec.add_dependency 'solidus_auth_devise'
   spec.add_dependency 'solidus_core', ['>= 2.0.0', '< 4']
   spec.add_dependency 'solidus_social'
@@ -44,4 +44,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'solidus_dev_support', '~> 2.5'
   spec.add_development_dependency 'vcr'
   spec.add_development_dependency 'webmock'
+  spec.add_development_dependency 'net-smtp'
 end


### PR DESCRIPTION
Rails 7 initializer is really different than rails 6 initializer, it
doesn't worth updating it now, we can support rails 7 later.
This commit allows also to use ruby greater than 2.5.