### PR TITLE
Infer merchant id and division id from

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,6 @@ Many of the API calls handled by this gem use the variables set in Bolt Configur
 
 ```
 BOLT_ENVIRONMENT
-BOLT_MERCHANT_PUBLIC_ID
-BOLT_DIVISION_PUBLIC_ID
 BOLT_API_KEY
 BOLT_SIGNING_SECRET
 BOLT_PUBLISHABLE_KEY

--- a/app/controllers/spree/admin/bolts_controller.rb
+++ b/app/controllers/spree/admin/bolts_controller.rb
@@ -30,8 +30,6 @@ module Spree
           .require(:solidus_bolt_bolt_configuration)
           .permit(
             :environment,
-            :merchant_public_id,
-            :division_public_id,
             :api_key,
             :signing_secret,
             :publishable_key

--- a/app/models/solidus_bolt/bolt_configuration.rb
+++ b/app/models/solidus_bolt/bolt_configuration.rb
@@ -15,6 +15,14 @@ module SolidusBolt
 
     validate :config_can_be_created, on: :create
 
+    def merchant_public_id
+      publishable_key.split('.').first
+    end
+
+    def division_public_id
+      publishable_key.split('.').second
+    end
+
     def self.fetch
       first_or_create
     end

--- a/app/views/spree/admin/bolts/_configuration.html.erb
+++ b/app/views/spree/admin/bolts/_configuration.html.erb
@@ -2,7 +2,7 @@
   <table class="index">
     <thead>
       <tr>
-        <th><%= SolidusBolt::BoltConfiguration.human_attribute_name(:merchant_public_id) %></th>
+        <th><%= SolidusBolt::BoltConfiguration.human_attribute_name(:publishable_key) %></th>
         <th><%= SolidusBolt::BoltConfiguration.human_attribute_name(:environment) %></th>
         <th><%= SolidusBolt::BoltConfiguration.human_attribute_name(:created_at) %></th>
         <th><%= SolidusBolt::BoltConfiguration.human_attribute_name(:updated_at) %></th>
@@ -11,7 +11,7 @@
     </thead>
     <tbody>
       <tr>
-        <td><%= @bolt_configuration.merchant_public_id %></td>
+        <td><%= @bolt_configuration.publishable_key %></td>
         <td><%= @bolt_configuration.environment %></td>
         <td>
           <%= @bolt_configuration.created_at.to_s(:long) %>

--- a/app/views/spree/admin/bolts/_form.html.erb
+++ b/app/views/spree/admin/bolts/_form.html.erb
@@ -6,10 +6,6 @@
         <div class="col-12">
           <%= f.label :environment %>
           <%= f.select :environment, %w[production sandbox staging] %><br />
-          <%= f.label 'Merchant Public Id' %><br />
-          <%= f.text_field :merchant_public_id, class: 'fullwidth' %>
-          <%= f.label 'Division Public Id' %><br />
-          <%= f.text_field :division_public_id, class: 'fullwidth' %>
           <%= f.label :api_key %><br />
           <%= f.text_field :api_key, class: 'fullwidth' %>
           <%= f.label :signing_secret %><br />

--- a/db/migrate/20220725133701_remove_merchant_id_and_division_public_id_on_bolt_configuration.rb
+++ b/db/migrate/20220725133701_remove_merchant_id_and_division_public_id_on_bolt_configuration.rb
@@ -1,0 +1,6 @@
+class RemoveMerchantIdAndDivisionPublicIdOnBoltConfiguration < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :solidus_bolt_bolt_configurations, :division_public_id, :string
+    remove_column :solidus_bolt_bolt_configurations, :merchant_public_id, :string
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -3,8 +3,6 @@
 solidus_bolt_configuration = SolidusBolt::BoltConfiguration.fetch
 
 solidus_bolt_configuration.environment = ENV.fetch('BOLT_ENVIRONMENT', 'sandbox')
-solidus_bolt_configuration.merchant_public_id = ENV['BOLT_MERCHANT_PUBLIC_ID']
-solidus_bolt_configuration.division_public_id = ENV['BOLT_DIVISION_PUBLIC_ID']
 solidus_bolt_configuration.api_key = ENV['BOLT_API_KEY']
 solidus_bolt_configuration.signing_secret = ENV['BOLT_SIGNING_SECRET']
 solidus_bolt_configuration.publishable_key = ENV['BOLT_PUBLISHABLE_KEY']

--- a/lib/solidus_bolt/testing_support/factories.rb
+++ b/lib/solidus_bolt/testing_support/factories.rb
@@ -3,11 +3,9 @@
 FactoryBot.define do
   factory :bolt_configuration, class: SolidusBolt::BoltConfiguration do
     environment { 'sandbox' }
-    merchant_public_id { SecureRandom.hex }
-    division_public_id { SecureRandom.hex }
     api_key { SecureRandom.hex }
     signing_secret { SecureRandom.hex }
-    publishable_key { SecureRandom.hex }
+    publishable_key { "#{SecureRandom.hex}.#{SecureRandom.hex}.#{SecureRandom.hex}" }
   end
 
   factory :bolt_payment_method, class: SolidusBolt::PaymentMethod do

--- a/spec/models/solidus_bolt/bolt_configuration_spec.rb
+++ b/spec/models/solidus_bolt/bolt_configuration_spec.rb
@@ -57,6 +57,20 @@ RSpec.describe SolidusBolt::BoltConfiguration, type: :model do
     end
   end
 
+  describe '#merchant_public_id' do
+    it 'returns the merchant_public_id' do
+      bolt_configuration = create(:bolt_configuration, publishable_key: 'abc.def.ghi')
+      expect(bolt_configuration.merchant_public_id).to eq('abc')
+    end
+  end
+
+  describe '#division_public_id' do
+    it 'returns the division_public_id' do
+      bolt_configuration = create(:bolt_configuration, publishable_key: 'abc.def.ghi')
+      expect(bolt_configuration.division_public_id).to eq('def')
+    end
+  end
+
   describe '#environment_url' do
     context 'when production envornment' do
       let(:config) { create(:bolt_configuration, environment: 'production') }

--- a/spec/models/solidus_bolt/bolt_configuration_spec.rb
+++ b/spec/models/solidus_bolt/bolt_configuration_spec.rb
@@ -5,8 +5,6 @@ RSpec.describe SolidusBolt::BoltConfiguration, type: :model do
     [
       'id',
       'environment',
-      'merchant_public_id',
-      'division_public_id',
       'api_key',
       'signing_secret',
       'publishable_key',
@@ -46,8 +44,6 @@ RSpec.describe SolidusBolt::BoltConfiguration, type: :model do
     it 'is true for a record with empty fields' do
       create(
         :bolt_configuration,
-        merchant_public_id: '',
-        division_public_id: '',
         api_key: '',
         signing_secret: '',
         publishable_key: ''

--- a/spec/requests/spree/admin/bolt_spec.rb
+++ b/spec/requests/spree/admin/bolt_spec.rb
@@ -6,8 +6,6 @@ RSpec.describe "Spree::Admin::Bolts", type: :request do
   let(:bolt_configuration_params) {
     {
       environment: 'sandbox',
-      merchant_public_id: SecureRandom.hex,
-      division_public_id: SecureRandom.hex,
       api_key: SecureRandom.hex,
       signing_secret: SecureRandom.hex,
       publishable_key: SecureRandom.hex
@@ -56,8 +54,6 @@ RSpec.describe "Spree::Admin::Bolts", type: :request do
 
       updated_attributes = SolidusBolt::BoltConfiguration.fetch.attributes.slice(
         'environment',
-        'merchant_public_id',
-        'division_public_id',
         'api_key',
         'signing_secret',
         'publishable_key'

--- a/spec/services/solidus_bolt/webhooks/create_service_spec.rb
+++ b/spec/services/solidus_bolt/webhooks/create_service_spec.rb
@@ -4,13 +4,15 @@ require 'spec_helper'
 
 RSpec.describe SolidusBolt::Webhooks::CreateService, :vcr, :bolt_configuration do
   describe '#call', vcr: true do
-    subject(:create) { described_class.call(url: 'https://solidus-test.com/webhook', event: event) }
+    subject(:create_service) { described_class.call(url: 'https://solidus-test.com/webhook', event: event) }
+
+    before { SolidusBolt::BoltConfiguration.fetch.update(publishable_key: 'abc.def.ghi') }
 
     context 'with an event' do
       let(:event) { 'payment' }
 
       it 'returns a webhook id' do
-        expect(create).to match hash_including('webhook_id')
+        expect(create_service).to match hash_including('webhook_id')
       end
     end
 
@@ -18,7 +20,7 @@ RSpec.describe SolidusBolt::Webhooks::CreateService, :vcr, :bolt_configuration d
       let(:event) { 'all' }
 
       it 'returns a webhook id' do
-        expect(create).to match hash_including('webhook_id')
+        expect(create_service).to match hash_including('webhook_id')
       end
     end
 
@@ -26,7 +28,7 @@ RSpec.describe SolidusBolt::Webhooks::CreateService, :vcr, :bolt_configuration d
       let(:event) { '' }
 
       it 'raises a server error' do
-        expect{ create }.to raise_error SolidusBolt::ServerError
+        expect{ create_service }.to raise_error SolidusBolt::ServerError
       end
     end
   end

--- a/spec/support/bolt_configuration.rb
+++ b/spec/support/bolt_configuration.rb
@@ -5,8 +5,6 @@ RSpec.configure do |config|
     solidus_bolt_configuration = SolidusBolt::BoltConfiguration.fetch
 
     solidus_bolt_configuration.environment = 'sandbox'
-    solidus_bolt_configuration.merchant_public_id = ENV['BOLT_MERCHANT_PUBLIC_ID']
-    solidus_bolt_configuration.division_public_id = ENV['BOLT_DIVISION_PUBLIC_ID']
     solidus_bolt_configuration.api_key = ENV['BOLT_API_KEY']
     solidus_bolt_configuration.signing_secret = ENV['BOLT_SIGNING_SECRET']
     solidus_bolt_configuration.publishable_key = ENV['BOLT_PUBLISHABLE_KEY']

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -20,7 +20,6 @@ VCR.configure do |config|
 
   config.filter_sensitive_data('<PUBLISHABLE_KEY>') { SolidusBolt::BoltConfiguration.fetch.publishable_key }
   config.filter_sensitive_data('<API_KEY>') { SolidusBolt::BoltConfiguration.fetch.api_key }
-  config.filter_sensitive_data('<DIVISION_ID>') { SolidusBolt::BoltConfiguration.fetch.division_public_id }
 
   # Let's you set default VCR record mode with VCR_RECORDE_MODE=all for re-recording
   # episodes. :once is VCR default


### PR DESCRIPTION
[Infer merchant_public_id and division_public_id](https://github.com/solidusio-contrib/solidus_bolt/commit/5306fde68ada1cad53e2a2bbf1b8bbaecf149210) 

Infer merchant_public_id and division_public_id from publishable_key, so
the merchant should fill only one field.