### PR TITLE
Re-enable submitButton after CC error

### DIFF
--- a/app/assets/javascripts/solidus_bolt.js
+++ b/app/assets/javascripts/solidus_bolt.js
@@ -16,6 +16,8 @@ const tokenize = async (paymentField, paymentMethodId, frontend) => {
     if (result["token"]) {
       updateOrder(result, paymentMethodId, frontend)
     } else {
+      const submitButton = document.getElementById("bolt-submit-button")
+      submitButton.disabled = false;
       console.log(`error ${result["type"]}: ${result["message"]}`);
     }
   });


### PR DESCRIPTION
When the submit button is clicked, it's disabled to prevent Debounce button issue, but was not re-enabled when the code fails.
This code fixes the problem re-enabling the button after the error.

