### PR TITLE
Remove the solidus_auth_devise gem from gemspec

### DIFF
--- a/solidus_bolt.gemspec
+++ b/solidus_bolt.gemspec
@@ -34,7 +34,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'multi_json'
   spec.add_dependency 'omniauth-bolt'
   spec.add_dependency 'rails'
-  spec.add_dependency 'solidus_auth_devise'
   spec.add_dependency 'solidus_core', ['>= 2.0.0', '< 4']
   spec.add_dependency 'solidus_social'
   spec.add_dependency 'solidus_support', '~> 0.5'


### PR DESCRIPTION
The `solidus_auth_devise` gem was added into the `gemspec` for this project as a typo in a previous commit.

The gem is already present in the `Gemfile` and doesn't need to be added as a dependency in the `gemspec` for the project.