### PR TITLE
Set merchant callbacks

### DIFF
--- a/app/controllers/spree/admin/bolt_callback_urls_controller.rb
+++ b/app/controllers/spree/admin/bolt_callback_urls_controller.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Spree
+  module Admin
+    class BoltCallbackUrlsController < Spree::Admin::BaseController
+      def new
+        callback_urls = SolidusBolt::MerchantConfiguration::GetCallbackUrlsService.call
+
+        @oauth_logout = callback_urls['callback_urls'].find { |c| c['type'] == 'oauth_logout' }['url']
+        @oauth_redirect = callback_urls['callback_urls'].find { |c| c['type'] == 'oauth_redirect' }['url']
+      end
+
+      def update
+        SolidusBolt::MerchantConfiguration::SetCallbackUrlsService.call(
+          oauth_logout: params[:bolt_callback_urls][:oauth_logout],
+          oauth_redirect: params[:bolt_callback_urls][:oauth_redirect]
+        )
+        flash[:success] = "Successfully updated callback urls."
+
+        redirect_to new_admin_bolt_callback_urls_path
+      rescue SolidusBolt::ServerError => e
+        flash[:error] = e.message
+
+        render :new
+      end
+
+      private
+
+      def bolt_webhook_params
+        params
+          .require(:bolt_webhook)
+          .permit(
+            :event,
+            :webhook_url,
+          )
+      end
+    end
+  end
+end

--- a/app/models/solidus_bolt/bolt_configuration.rb
+++ b/app/models/solidus_bolt/bolt_configuration.rb
@@ -16,11 +16,11 @@ module SolidusBolt
     validate :config_can_be_created, on: :create
 
     def merchant_public_id
-      publishable_key.split('.').first
+      publishable_key&.split('.')&.first
     end
 
     def division_public_id
-      publishable_key.split('.').second
+      publishable_key&.split('.')&.second
     end
 
     def self.fetch

--- a/app/services/solidus_bolt/merchant_configuration/get_callback_urls_service.rb
+++ b/app/services/solidus_bolt/merchant_configuration/get_callback_urls_service.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module SolidusBolt
+  module MerchantConfiguration
+    class GetCallbackUrlsService < SolidusBolt::BaseService
+      attr_reader :oauth_redirect, :oauth_logout, :get_account
+
+      def call
+        get_callbacks
+      end
+
+      private
+
+      def get_callbacks # rubocop:disable Naming/AccessorMethodName
+        url = "#{api_base_url}/#{api_version}/merchant/callbacks"
+        handle_result(
+          HTTParty.get(
+            url, headers: headers, query: query
+          )
+        )
+      end
+
+      def query
+        {
+          division_id: @config.division_public_id
+        }
+      end
+
+      def headers
+        {
+          'Content-Type' => 'application/json',
+        }.merge(authentication_header)
+      end
+    end
+  end
+end

--- a/app/services/solidus_bolt/merchant_configuration/set_callback_urls_service.rb
+++ b/app/services/solidus_bolt/merchant_configuration/set_callback_urls_service.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module SolidusBolt
+  module MerchantConfiguration
+    class SetCallbackUrlsService < SolidusBolt::BaseService
+      attr_reader :oauth_redirect, :oauth_logout, :get_account
+
+      def initialize(oauth_redirect: nil, oauth_logout: nil, get_account: nil)
+        @oauth_redirect = oauth_redirect
+        @oauth_logout = oauth_logout
+        @get_account = get_account
+
+        super
+      end
+
+      def call
+        set_callbacks
+      end
+
+      private
+
+      def set_callbacks
+        url = "#{api_base_url}/#{api_version}/merchant/callbacks"
+        handle_result(
+          HTTParty.post(
+            url, headers: headers, body: body.to_json
+          )
+        )
+      end
+
+      def body
+        {
+          division_id: @config.division_public_id,
+          callback_urls: callback_urls
+        }
+      end
+
+      def callback_urls
+        callback_urls = []
+
+        callback_urls <<  { type: 'oauth_redirect', url: oauth_redirect } if oauth_redirect.present?
+        callback_urls <<  { type: 'oauth_logout', url: oauth_logout } if oauth_logout.present?
+        callback_urls <<  { type: 'get_account', url: get_account } if get_account.present?
+
+        callback_urls
+      end
+
+      def headers
+        {
+          'Content-Type' => 'application/json',
+        }.merge(authentication_header)
+      end
+    end
+  end
+end

--- a/app/views/spree/admin/bolt_callback_urls/new.html.erb
+++ b/app/views/spree/admin/bolt_callback_urls/new.html.erb
@@ -1,0 +1,24 @@
+<% admin_breadcrumb(plural_resource_name(SolidusBolt::BoltConfiguration)) %>
+
+<%= form_for :bolt_callback_urls, url: admin_bolt_callback_urls_path, method: :patch do |f| %>
+  <fieldset class="form-group no-border-bottom no-border-top">
+    <div class="row">
+      <div id="general_fields" class="col-9">
+        <div class="row">
+          <div class="col-12">
+            <%= f.label :oauth_redirect %>
+            <%= f.text_field :oauth_redirect, class: 'fullwidth', value: @oauth_redirect || 'https://domain.com/webhooks/bolt' %>
+          </div>
+          <div class="col-12">
+            <%= f.label :oauth_logout %>
+            <%= f.text_field :oauth_logout, class: 'fullwidth', value: @oauth_logout || 'https://domain.com/webhooks/bolt' %>
+          </div>
+        </div>
+        <div class="row p-2 justify-content-center">
+          <%= f.submit 'Update', class: 'btn btn-primary', data: { disable_with: 'Creating..' } %>
+          <%= link_to 'Cancel', admin_bolt_path, class: 'button' %>
+        </div>
+      </div>
+    </div>
+  </fieldset>
+<% end %>

--- a/app/views/spree/admin/bolts/show.html.erb
+++ b/app/views/spree/admin/bolts/show.html.erb
@@ -12,6 +12,9 @@
     </li>
   <% else %>
     <li>
+      <%= link_to 'Configure Callbacks URLs', new_admin_bolt_callback_urls_path, class: 'btn btn-primary' %>
+    </li>
+    <li>
       <%= link_to 'Configure Webhooks', new_admin_bolt_webhook_path, class: 'btn btn-primary' %>
     </li>
   <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Spree::Core::Engine.routes.draw do
   namespace :admin do
     resource :bolt, only: [:show, :edit, :update]
     resource :bolt_webhook, only: [:new, :create]
+    resource :bolt_callback_urls, only: [:new, :update]
   end
 
   post '/webhooks/bolt', to: '/solidus_bolt/webhooks#update'

--- a/spec/fixtures/vcr_cassettes/SolidusBolt_MerchantConfiguration_GetCallbackUrlsService/_call/receives_the_correct_response.yml
+++ b/spec/fixtures/vcr_cassettes/SolidusBolt_MerchantConfiguration_GetCallbackUrlsService/_call/receives_the_correct_response.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api-sandbox.bolt.com/v1/merchant/callbacks?division_id=<DIVISION_PUBLIC_ID>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Content-Type:
+      - application/json
+      X-Api-Key:
+      - "<API_KEY>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Jul 2022 18:10:11 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '157'
+      Connection:
+      - keep-alive
+      Public-Key-Pins-Report-Only:
+      - max-age=2592000;pin-sha256="OGAVOYhLZd3ADKYGFZOED1c5m1ObMlRv9PyIWrO4Nd0=";pin-sha256="RRM1dGqnDFsCJXBTHky16vi1obOlCgFFn/yOhI/y+ho=";pin-sha256="IXHYSIdST+XY22J5ivybYkntMIfjA5P6pMKX2hWG1BE=";report-uri="https://77aa1bd121ef22d50247a23390ce6cff.report-uri.io/r/default/hpkp/reportOnly"
+      Set-Cookie:
+      - trk=f47ec1df-c6f5-460c-baf3-2ff506846dd2; Path=/; Max-Age=31536000; HttpOnly;
+        Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Bolt-Api-Version:
+      - '2022-01-01'
+      X-Bolt-Trace-Id:
+      - Root=1-62e17f83-46d90f8f25fd210e0420dbdb
+      X-Device-Id:
+      - cc0e49b483c9bdb9dce4a6f35b9fcfb75194e19da94e18882fac74a192a8fc71
+      X-Envoy-Upstream-Service-Time:
+      - '29'
+      Server:
+      - envoy
+    body:
+      encoding: UTF-8
+      string: '{"callback_urls":[{"url":"http://localhost:3000/bolt_logout","type":"oauth_logout"},{"url":"http://localhost:3000/users/auth/bolt","type":"oauth_redirect"}]}'
+  recorded_at: Wed, 27 Jul 2022 18:10:11 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/SolidusBolt_MerchantConfiguration_SetCallbackUrlsService/_call/receives_the_correct_response.yml
+++ b/spec/fixtures/vcr_cassettes/SolidusBolt_MerchantConfiguration_SetCallbackUrlsService/_call/receives_the_correct_response.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api-sandbox.bolt.com/v1/merchant/callbacks
+    body:
+      encoding: UTF-8
+      string: '{"division_id":"Rq4qB1QajYLn","callback_urls":[{"type":"oauth_redirect","url":"http://localhost:3000/users/auth/bolt"},{"type":"oauth_logout","url":"http://localhost:3000//user/spree_user/logout"}]}'
+    headers:
+      Content-Type:
+      - application/json
+      X-Api-Key:
+      - "<API_KEY>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 26 Jul 2022 21:17:15 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '4'
+      Connection:
+      - keep-alive
+      Public-Key-Pins-Report-Only:
+      - max-age=2592000;pin-sha256="OGAVOYhLZd3ADKYGFZOED1c5m1ObMlRv9PyIWrO4Nd0=";pin-sha256="RRM1dGqnDFsCJXBTHky16vi1obOlCgFFn/yOhI/y+ho=";pin-sha256="IXHYSIdST+XY22J5ivybYkntMIfjA5P6pMKX2hWG1BE=";report-uri="https://77aa1bd121ef22d50247a23390ce6cff.report-uri.io/r/default/hpkp/reportOnly"
+      Set-Cookie:
+      - trk=ea8f518e-f41d-4b8c-9615-161bff916a0f; Path=/; Max-Age=31536000; HttpOnly;
+        Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Bolt-Api-Version:
+      - '2022-01-01'
+      X-Bolt-Trace-Id:
+      - Root=1-62e059db-307d2def557ae7d63cda1f93
+      X-Device-Id:
+      - 65fb9d676354668c7128f58217c94230e32303007b66559078fee6aefb88e8a4
+      X-Envoy-Upstream-Service-Time:
+      - '37'
+      Server:
+      - envoy
+    body:
+      encoding: UTF-8
+      string: 'null'
+  recorded_at: Tue, 26 Jul 2022 21:17:15 GMT
+recorded_with: VCR 6.1.0

--- a/spec/models/solidus_bolt/bolt_configuration_spec.rb
+++ b/spec/models/solidus_bolt/bolt_configuration_spec.rb
@@ -62,12 +62,22 @@ RSpec.describe SolidusBolt::BoltConfiguration, type: :model do
       bolt_configuration = create(:bolt_configuration, publishable_key: 'abc.def.ghi')
       expect(bolt_configuration.merchant_public_id).to eq('abc')
     end
+
+    it 'returns nil if publishable_key is nil' do
+      bolt_configuration = create(:bolt_configuration, publishable_key: nil)
+      expect(bolt_configuration.division_public_id).to be_nil
+    end
   end
 
   describe '#division_public_id' do
     it 'returns the division_public_id' do
       bolt_configuration = create(:bolt_configuration, publishable_key: 'abc.def.ghi')
       expect(bolt_configuration.division_public_id).to eq('def')
+    end
+
+    it 'returns nil if publishable_key is nil' do
+      bolt_configuration = create(:bolt_configuration, publishable_key: nil)
+      expect(bolt_configuration.division_public_id).to be_nil
     end
   end
 

--- a/spec/services/solidus_bolt/merchant_configuration/get_callback_urls_service_spec.rb
+++ b/spec/services/solidus_bolt/merchant_configuration/get_callback_urls_service_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SolidusBolt::MerchantConfiguration::GetCallbackUrlsService, :vcr, :bolt_configuration do
+  subject(:api) { described_class.new }
+
+  describe '#call', vcr: true do
+    it 'receives the correct response' do
+      expect(api.call).to match hash_including(
+        'callback_urls' => array_including(hash_including('type', 'url'))
+      )
+    end
+  end
+end

--- a/spec/services/solidus_bolt/merchant_configuration/set_callback_urls_service_spec.rb
+++ b/spec/services/solidus_bolt/merchant_configuration/set_callback_urls_service_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SolidusBolt::MerchantConfiguration::SetCallbackUrlsService, :vcr, :bolt_configuration do
+  subject(:api) { described_class.new(params) }
+
+  let(:params) {
+    {
+      oauth_redirect: 'http://localhost:3000/users/auth/bolt',
+      oauth_logout: 'http://localhost:3000//user/spree_user/logout'
+    }
+  }
+
+  describe '#call', vcr: true do
+    it 'receives the correct response' do
+      expect(api.call).to be_nil
+    end
+  end
+end

--- a/spec/support/bolt_configuration.rb
+++ b/spec/support/bolt_configuration.rb
@@ -7,7 +7,7 @@ RSpec.configure do |config|
     solidus_bolt_configuration.environment = 'sandbox'
     solidus_bolt_configuration.api_key = ENV['BOLT_API_KEY']
     solidus_bolt_configuration.signing_secret = ENV['BOLT_SIGNING_SECRET']
-    solidus_bolt_configuration.publishable_key = ENV['BOLT_PUBLISHABLE_KEY']
+    solidus_bolt_configuration.publishable_key = ENV['BOLT_PUBLISHABLE_KEY'] || 'abc.def.ghi'
 
     solidus_bolt_configuration.save!
 

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -19,6 +19,7 @@ VCR.configure do |config|
   end
 
   config.filter_sensitive_data('<PUBLISHABLE_KEY>') { SolidusBolt::BoltConfiguration.fetch.publishable_key }
+  config.filter_sensitive_data('<DIVISION_PUBLIC_ID>') { SolidusBolt::BoltConfiguration.fetch.division_public_id }
   config.filter_sensitive_data('<API_KEY>') { SolidusBolt::BoltConfiguration.fetch.api_key }
 
   # Let's you set default VCR record mode with VCR_RECORDE_MODE=all for re-recording


### PR DESCRIPTION
This PR adds the ability to the merchant to configure the oauth_redirect and the oauth_logout URLs on Bolt.
The solidus admin page is available at `/admin/bolt_callback_urls/new`, and it retrieves and displays the current configuration from Bolt.

The page uses 2 services, [one](https://github.com/solidusio-contrib/solidus_bolt/commit/4910c545d1b1789e3b4d9a2f774821a34dae6d2d) to retrieve the info and the [other](6f02fedb437c1d4134eba5f3405f1095100e0875) to set them.