### PR TITLE
SSO logout button

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,4 +9,8 @@ Spree::Core::Engine.routes.draw do
 
   post '/webhooks/bolt', to: '/solidus_bolt/webhooks#update'
   post '/api/accounts/bolt', to: '/solidus_bolt/accounts#create'
+
+  devise_scope :spree_user do
+    get '/bolt_logout', to: '/spree/user_sessions#destroy', as: 'bolt_logout'
+  end
 end

--- a/lib/views/frontend/spree/shared/_login_bar_items.html.erb
+++ b/lib/views/frontend/spree/shared/_login_bar_items.html.erb
@@ -1,6 +1,6 @@
 <% if spree_current_user %>
   <li><%= link_to t('spree.my_account'), spree.account_path %></li>
-  <li><%= link_to t('spree.logout'), spree.logout_path, method: Devise.sign_out_via %></li>
+  <li><div class="bolt-account-sso" data-logged-in="true"></div></li>
 <% else %>
   <li>
     <div class="bolt-account-sso"></div>


### PR DESCRIPTION
This PR adds the ability to log out the user from both Bolt and Solidus sessions with one click.
In order to do it, Bolt provides a js code that uses a specific div:

`<div class="bolt-account-sso" data-logged-in="true"></div>`

to handle the click and sign out the user from the bolt session, and then redirect the user to the Solidus logout page.

<img width="404" alt="Screenshot 2022-07-27 at 19 14 16" src="https://user-images.githubusercontent.com/387690/181308694-bd35b2dc-7e47-455c-9533-feb857d442e8.png">